### PR TITLE
Add more specific syntax schemes for AvalonEdit

### DIFF
--- a/src/CosmosDBStudio/App.xaml.cs
+++ b/src/CosmosDBStudio/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using CosmosDBStudio.ViewModel;
+﻿using CosmosDBStudio.SyntaxHighlighting;
+using CosmosDBStudio.ViewModel;
 using System.Windows;
 
 namespace CosmosDBStudio
@@ -9,6 +10,7 @@ namespace CosmosDBStudio
 
         public App(MainWindowViewModel mainWindowViewModel)
         {
+            CosmosSyntax.Init();
             InitializeComponent();
             _mainWindowViewModel = mainWindowViewModel;
         }

--- a/src/CosmosDBStudio/CosmosDBStudio.csproj
+++ b/src/CosmosDBStudio/CosmosDBStudio.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="SyntaxHighlighting\*.xshd" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Resource Include="Resources\fa-solid-900.ttf" />
   </ItemGroup>
 

--- a/src/CosmosDBStudio/SyntaxHighlighting/CosmosJS.xshd
+++ b/src/CosmosDBStudio/SyntaxHighlighting/CosmosJS.xshd
@@ -1,0 +1,131 @@
+﻿<?xml version="1.0"?>
+<!-- syntaxdefinition for JavaScript 2.0 by Svante Lidman -->
+<!-- converted to AvalonEdit format by Siegfried Pammer in 2010 -->
+<SyntaxDefinition name="CosmosJS" extensions=".js" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+	<Color name="Digits" foreground="DarkBlue" exampleText="3.14" />
+	<Color name="Comment" foreground="Green" exampleText="// comment" />
+	<Color name="String" foreground="Sienna" exampleText="var text = &quot;Hello, World!&quot;;" />
+	<Color name="Character" foreground="Sienna" exampleText="var char = 'a';" />
+	<Color name="Regex" foreground="Sienna" exampleText="/abc/m" />
+	<Color name="JavaScriptKeyWords" foreground="Blue" exampleText="return myVariable;" />
+	<Color name="JavaScriptIntrinsics" foreground="Blue" exampleText="Math.random()" />
+	<Color name="JavaScriptLiterals" foreground="Blue" exampleText="return false;" />
+	<Color name="JavaScriptGlobalFunctions" foreground="Blue" exampleText="escape(myString);" />
+	<RuleSet ignoreCase="false">
+		<Keywords color="JavaScriptKeyWords">
+			<Word>break</Word>
+			<Word>continue</Word>
+			<Word>delete</Word>
+			<Word>else</Word>
+			<Word>for</Word>
+			<Word>function</Word>
+			<Word>if</Word>
+			<Word>in</Word>
+			<Word>new</Word>
+			<Word>return</Word>
+			<Word>this</Word>
+			<Word>typeof</Word>
+			<Word>var</Word>
+			<Word>void</Word>
+			<Word>while</Word>
+			<Word>with</Word>
+			<Word>abstract</Word>
+			<Word>boolean</Word>
+			<Word>byte</Word>
+			<Word>case</Word>
+			<Word>catch</Word>
+			<Word>char</Word>
+			<Word>class</Word>
+			<Word>const</Word>
+			<Word>debugger</Word>
+			<Word>default</Word>
+			<Word>do</Word>
+			<Word>double</Word>
+			<Word>enum</Word>
+			<Word>export</Word>
+			<Word>extends</Word>
+			<Word>final</Word>
+			<Word>finally</Word>
+			<Word>float</Word>
+			<Word>goto</Word>
+			<Word>implements</Word>
+			<Word>import</Word>
+			<Word>instanceof</Word>
+			<Word>int</Word>
+			<Word>interface</Word>
+			<Word>long</Word>
+			<Word>native</Word>
+			<Word>package</Word>
+			<Word>private</Word>
+			<Word>protected</Word>
+			<Word>public</Word>
+			<Word>short</Word>
+			<Word>static</Word>
+			<Word>super</Word>
+			<Word>switch</Word>
+			<Word>synchronized</Word>
+			<Word>throw</Word>
+			<Word>throws</Word>
+			<Word>transient</Word>
+			<Word>try</Word>
+			<Word>volatile</Word>
+			<Word>let</Word>
+			<Word>async</Word>
+			<Word>await</Word>
+		</Keywords>
+		<Keywords color="JavaScriptIntrinsics">
+			<Word>Array</Word>
+			<Word>Boolean</Word>
+			<Word>Date</Word>
+			<Word>Function</Word>
+			<Word>Global</Word>
+			<Word>Math</Word>
+			<Word>Number</Word>
+			<Word>Object</Word>
+			<Word>RegExp</Word>
+			<Word>String</Word>
+		</Keywords>
+		<Keywords color="JavaScriptLiterals">
+			<Word>false</Word>
+			<Word>null</Word>
+			<Word>true</Word>
+			<Word>NaN</Word>
+			<Word>Infinity</Word>
+		</Keywords>
+		<Keywords color="JavaScriptGlobalFunctions">
+			<Word>eval</Word>
+			<Word>parseInt</Word>
+			<Word>parseFloat</Word>
+			<Word>escape</Word>
+			<Word>unescape</Word>
+			<Word>isNaN</Word>
+			<Word>isFinite</Word>
+		</Keywords>
+		<Span color="Comment">
+			<Begin>//</Begin>
+		</Span>
+		<Span color="Comment" multiline="true">
+			<Begin>/\*</Begin>
+			<End>\*/</End>
+		</Span>
+		<Span color="Regex">
+			<Begin>(?&lt;!([})\]\w]+\s*))/</Begin>
+			<End>/</End>
+		</Span>
+		<Span color="String" multiline="true">
+			<Begin>"</Begin>
+			<End>"</End>
+			<RuleSet>
+				<Span begin="\\" end="." />
+			</RuleSet>
+		</Span>
+		<Span color="Character">
+			<Begin>'</Begin>
+			<End>'</End>
+			<RuleSet>
+				<Span begin="\\" end="." />
+			</RuleSet>
+		</Span>
+		<Rule color="Digits">\b0[xX][0-9a-fA-F]+|(\b\d+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?</Rule>
+	</RuleSet>
+</SyntaxDefinition>

--- a/src/CosmosDBStudio/SyntaxHighlighting/CosmosSQL.xshd
+++ b/src/CosmosDBStudio/SyntaxHighlighting/CosmosSQL.xshd
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0"?>
+<SyntaxDefinition name="CosmosSQL" extensions=".sql" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+  <Color name="Comment" foreground="Green" exampleText="-- comment" />
+  <Color name="Char" foreground="Red" exampleText="name = 'abc'"/>
+  <Color name="Keywords" fontWeight="bold" foreground="Blue" exampleText="SELECT FROM"/>
+
+  <RuleSet name="CommentMarkerSet">
+    <Keywords fontWeight="bold" foreground="Red">
+      <Word>TODO</Word>
+      <Word>FIXME</Word>
+    </Keywords>
+    <Keywords fontWeight="bold" foreground="#E0E000">
+      <Word>HACK</Word>
+      <Word>UNDONE</Word>
+    </Keywords>
+  </RuleSet>
+
+  <RuleSet ignoreCase="true">
+    <Span color="Comment" ruleSet="CommentMarkerSet">
+      <Begin>--</Begin>
+    </Span>
+
+    <Span color="Comment" ruleSet="CommentMarkerSet" multiline="true">
+      <Begin>/\*</Begin>
+      <End>\*/</End>
+    </Span>
+
+    <Span color="Char">
+      <Begin>'</Begin>
+      <End>'</End>
+      <RuleSet>
+        <Span begin="\\" end="."/>
+      </RuleSet>
+    </Span>
+
+    <Keywords color="Keywords">
+      <Word>select</Word>
+      <Word>from</Word>
+      <Word>where</Word>
+      <Word>order</Word>
+      <Word>group</Word>
+      <Word>by</Word>
+      <Word>and</Word>
+      <Word>or</Word>
+      <Word>not</Word>
+      <Word>offset</Word>
+      <Word>limit</Word>
+      <Word>value</Word>
+      <Word>distinct</Word>
+      <Word>as</Word>
+      <Word>join</Word>
+      <Word>in</Word>
+      <Word>between</Word>
+      <Word>top</Word>
+      <Word>asc</Word>
+      <Word>desc</Word>
+      <Word>count</Word>
+      <Word>sum</Word>
+      <Word>min</Word>
+      <Word>max</Word>
+      <Word>avg</Word>
+      <Word>udf</Word>
+      <Word>sum</Word>
+      <Word>array_concat</Word>
+      <Word>array_contains</Word>
+      <Word>array_length</Word>
+      <Word>array_slice</Word>
+      <Word>array_concat</Word>
+      <Word>GetCurrentDateTime</Word>
+      <Word>GetCurrentTimestamp</Word>
+      <Word>GetCurrentTicks</Word>
+      <Word>DateTimeAdd</Word>
+      <Word>DateTimeDiff</Word>
+      <Word>DateTimeFromParts</Word>
+      <Word>DateTimePart</Word>
+      <Word>DateTimeToTicks</Word>
+      <Word>DateTimeToTimestamp</Word>
+      <Word>TicksToDateTime</Word>
+      <Word>TimestampToDateTime</Word>
+      <Word>abs</Word>
+      <Word>acos</Word>
+      <Word>asin</Word>
+      <Word>atan</Word>
+      <Word>atn2</Word>
+      <Word>ceiling</Word>
+      <Word>cos</Word>
+      <Word>cot</Word>
+      <Word>degrees</Word>
+      <Word>exp</Word>
+      <Word>floor</Word>
+      <Word>log</Word>
+      <Word>log10</Word>
+      <Word>pi</Word>
+      <Word>power</Word>
+      <Word>radians</Word>
+      <Word>rand</Word>
+      <Word>round</Word>
+      <Word>sign</Word>
+      <Word>sin</Word>
+      <Word>sqrt</Word>
+      <Word>square</Word>
+      <Word>tan</Word>
+      <Word>trunc</Word>
+
+    </Keywords>
+  </RuleSet>
+</SyntaxDefinition>

--- a/src/CosmosDBStudio/SyntaxHighlighting/CosmosSyntax.cs
+++ b/src/CosmosDBStudio/SyntaxHighlighting/CosmosSyntax.cs
@@ -1,0 +1,30 @@
+﻿using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Highlighting.Xshd;
+using System;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace CosmosDBStudio.SyntaxHighlighting
+{
+    internal static class CosmosSyntax
+    {
+        public static void Init()
+        {
+            var assembly = typeof(CosmosSyntax).Assembly;
+            var regex = new Regex(@"CosmosDBStudio\.SyntaxHighlighting\.(?<syntaxName>[a-zA-Z0-9-_]+).xshd");
+            var resourceNames = assembly.GetManifestResourceNames();
+            foreach (var resourceName in resourceNames)
+            {
+                var match = regex.Match(resourceName);
+                if (!match.Success)
+                    continue;
+
+                var syntaxName = match.Groups["syntaxName"].Value;
+                using var stream = assembly.GetManifestResourceStream(resourceName);
+                using var reader = XmlReader.Create(stream);
+                var definition = HighlightingLoader.Load(reader, HighlightingManager.Instance);
+                HighlightingManager.Instance.RegisterHighlighting(syntaxName, Array.Empty<string>(), definition);
+            }
+        }
+    }
+}

--- a/src/CosmosDBStudio/SyntaxHighlighting/JSON.xshd
+++ b/src/CosmosDBStudio/SyntaxHighlighting/JSON.xshd
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- syntaxdefinition for Json by alek kowalczyk -->
+<!-- update by zuijin in 2019.12.20 -->
+<SyntaxDefinition name="JSON" extensions=".json" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+  <Color name="Bool" foreground="Blue" exampleText="true | false" />
+  <Color name="Number" foreground="#098658" exampleText="3.14" />
+  <Color name="String" foreground="#a31515" exampleText="" />
+  <Color name="Null" foreground="Blue" exampleText="" />
+  <Color name="FieldName" foreground="#0451a5" />
+  <Color name="Punctuation" foreground="Black" />
+
+  <RuleSet name="String">
+    <Span begin="\\" end="."/>
+  </RuleSet>
+
+  <RuleSet name="Object">
+    <Span color="FieldName" ruleSet="String">
+      <Begin>"</Begin>
+      <End>"</End>
+    </Span>
+    <Span color="FieldName" ruleSet="String">
+      <Begin>'</Begin>
+      <End>'</End>
+    </Span>
+    <Span color="Punctuation" ruleSet="Expression">
+      <Begin>:</Begin>
+    </Span>
+    <Span color="Punctuation">
+      <Begin>,</Begin>
+    </Span>
+  </RuleSet>
+
+  <RuleSet name="Array">
+    <Import ruleSet="Expression"/>
+    <Span color="Punctuation">
+      <Begin>,</Begin>
+    </Span>
+  </RuleSet>
+
+  <RuleSet name="Expression">
+    <Keywords color="Bool" >
+      <Word>true</Word>
+      <Word>false</Word>
+    </Keywords>
+    <Keywords color="Null" >
+      <Word>null</Word>
+    </Keywords>
+    <Span color="String" ruleSet="String">
+      <Begin>"</Begin>
+      <End>"</End>
+    </Span>
+    <Span color="String" ruleSet="String">
+      <Begin>'</Begin>
+      <End>'</End>
+    </Span>
+    <Span color="Punctuation" ruleSet="Object" multiline="true">
+      <Begin>\{</Begin>
+      <End>\}</End>
+    </Span>
+    <Span color="Punctuation" ruleSet="Array" multiline="true">
+      <Begin>\[</Begin>
+      <End>\]</End>
+    </Span>
+    <Rule color="Number">
+      \b0[xX][0-9a-fA-F]+|(\b\d+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?
+    </Rule>
+  </RuleSet>
+
+  <RuleSet>
+    <Import ruleSet="Expression"/>
+  </RuleSet>
+</SyntaxDefinition>

--- a/src/CosmosDBStudio/View/DocumentEditorView.xaml
+++ b/src/CosmosDBStudio/View/DocumentEditorView.xaml
@@ -32,7 +32,7 @@
                     CommandParameter="{StaticResource True}" />
         </ToolBar>
         <avalonEdit:TextEditor Grid.Row="1"
-                               SyntaxHighlighting="JavaScript"
+                               SyntaxHighlighting="JSON"
                                FontFamily="{StaticResource CodeFont}">
             <i:Interaction.Behaviors>
                 <bhv:AvalonTextEditorBehavior UseSearch="True" />

--- a/src/CosmosDBStudio/View/QueryResultsView.xaml
+++ b/src/CosmosDBStudio/View/QueryResultsView.xaml
@@ -53,7 +53,7 @@
                                 Command="{Binding DeleteCommand}" />
                     </ToolBar>
                     <avalonEdit:TextEditor
-                                       SyntaxHighlighting="JavaScript"
+                                       SyntaxHighlighting="JSON"
                                        FontFamily="{StaticResource CodeFont}"
                                        IsReadOnly="True">
                         <i:Interaction.Behaviors>
@@ -66,7 +66,7 @@
             </Grid>
         </TabItem>
         <TabItem Header="Raw">
-            <avalonEdit:TextEditor SyntaxHighlighting="JavaScript" IsReadOnly="True"
+            <avalonEdit:TextEditor SyntaxHighlighting="JSON" IsReadOnly="True"
                                    FontFamily="{StaticResource CodeFont}">
                 <i:Interaction.Behaviors>
                     <bhv:AvalonTextEditorBehavior UseSearch="True" />

--- a/src/CosmosDBStudio/View/QuerySheetView.xaml
+++ b/src/CosmosDBStudio/View/QuerySheetView.xaml
@@ -74,7 +74,7 @@
                 <ColumnDefinition x:Name="editorColumn" Width="*" />
                 <ColumnDefinition x:Name="parametersColumn" Width="0" />
             </Grid.ColumnDefinitions>
-            <avalonEdit:TextEditor Grid.Column="0" SyntaxHighlighting="TSQL" FontFamily="{StaticResource CodeFont}">
+            <avalonEdit:TextEditor Grid.Column="0" SyntaxHighlighting="CosmosSQL" FontFamily="{StaticResource CodeFont}">
                 <i:Interaction.Behaviors>
                     <bhv:AvalonTextEditorBehavior UseSearch="True" />
                     <bhv:AvalonTextEditorBindingBehavior

--- a/src/CosmosDBStudio/View/StoredProcedureEditorView.xaml
+++ b/src/CosmosDBStudio/View/StoredProcedureEditorView.xaml
@@ -46,7 +46,7 @@
                 <ColumnDefinition x:Name="editorColumn" Width="*" />
                 <ColumnDefinition x:Name="parametersColumn" Width="0" />
             </Grid.ColumnDefinitions>
-            <avalonEdit:TextEditor SyntaxHighlighting="JavaScript" FontFamily="{StaticResource CodeFont}">
+            <avalonEdit:TextEditor SyntaxHighlighting="CosmosJS" FontFamily="{StaticResource CodeFont}">
                 <i:Interaction.Behaviors>
                     <bhv:AvalonTextEditorBehavior UseSearch="True" />
                     <bhv:AvalonTextEditorBindingBehavior

--- a/src/CosmosDBStudio/View/StoredProcedureResultView.xaml
+++ b/src/CosmosDBStudio/View/StoredProcedureResultView.xaml
@@ -15,7 +15,7 @@
     </UserControl.Resources>
     <TabControl SelectedIndex="{Binding SelectedTab, Mode=TwoWay, Converter={StaticResource enumConverter}}">
         <TabItem Header="Raw">
-            <avalonEdit:TextEditor SyntaxHighlighting="JavaScript" IsReadOnly="True"
+            <avalonEdit:TextEditor SyntaxHighlighting="JSON" IsReadOnly="True"
                                    FontFamily="{StaticResource CodeFont}">
                 <i:Interaction.Behaviors>
                     <bhv:AvalonTextEditorBehavior UseSearch="True" />

--- a/src/CosmosDBStudio/View/TriggerEditorView.xaml
+++ b/src/CosmosDBStudio/View/TriggerEditorView.xaml
@@ -48,7 +48,7 @@
                 <cosmos:TriggerOperation>Replace</cosmos:TriggerOperation>
             </ComboBox>
         </ToolBar>
-        <avalonEdit:TextEditor Grid.Row="2" SyntaxHighlighting="JavaScript" FontFamily="{StaticResource CodeFont}">
+        <avalonEdit:TextEditor Grid.Row="2" SyntaxHighlighting="CosmosJS" FontFamily="{StaticResource CodeFont}">
             <i:Interaction.Behaviors>
                 <bhv:AvalonTextEditorBehavior UseSearch="True" />
                 <bhv:AvalonTextEditorBindingBehavior

--- a/src/CosmosDBStudio/View/UserDefinedFunctionEditorView.xaml
+++ b/src/CosmosDBStudio/View/UserDefinedFunctionEditorView.xaml
@@ -31,7 +31,7 @@
                     Command="{Binding RevertCommand}" />
         </ToolBar>
         <Grid Grid.Row="2">
-            <avalonEdit:TextEditor SyntaxHighlighting="JavaScript" FontFamily="{StaticResource CodeFont}">
+            <avalonEdit:TextEditor SyntaxHighlighting="CosmosJS" FontFamily="{StaticResource CodeFont}">
                 <i:Interaction.Behaviors>
                     <bhv:AvalonTextEditorBehavior UseSearch="True" />
                     <bhv:AvalonTextEditorBindingBehavior


### PR DESCRIPTION
Fixes #32
Introduce 3 syntax schemes:
- JSON (was previously using Javascript, which didn't work very well because keys and values had the same color)
- CosmosJS : same as the default Javascript syntax from AvalonEdit, with a few additional keywords (async, await, let)
- CosmosSQL : based on the default TSQL syntax from AvalonEdit, but with CosmosDB specific keywords, and without unsupported keywords