### PR TITLE
Provide a default query on an empty query sheet

### DIFF
--- a/src/CosmosDBStudio.Model/QuerySheet.cs
+++ b/src/CosmosDBStudio.Model/QuerySheet.cs
@@ -4,9 +4,10 @@ namespace CosmosDBStudio.Model
 {
     public class QuerySheet
     {
+        private const string DefaultQuery = "select * from c";
         public const string FileFilter = "Cosmos DB Studio query sheet|*.cdbsqs";
 
-        public string Text { get; set; } = string.Empty;
+        public string Text { get; set; } = DefaultQuery;
         public string? PartitionKey { get; set; }
         public IList<string> PartitionKeyMRU { get; set; } = new List<string>();
         public IList<QuerySheetParameter> Parameters { get; set; } = new List<QuerySheetParameter>();

--- a/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
+++ b/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
@@ -22,7 +22,7 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
     public class QuerySheetViewModel : TabViewModelBase, ISaveable
     {
         public static int UntitledCounter { get; set; }
-
+        private const string DefaultQuery = "select * from c";
         private readonly IViewModelFactory _viewModelFactory;
         private readonly IDialogService _dialogService;
         private readonly IMessenger _messenger;
@@ -48,7 +48,7 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
             _title = string.IsNullOrEmpty(path)
                 ? "Untitled " + (++UntitledCounter)
                 : Path.GetFileNameWithoutExtension(path);
-            _text = querySheet.Text;
+            _text = querySheet.Text == string.Empty ? DefaultQuery : querySheet.Text;
             _result = _viewModelFactory.CreateNotRunQueryResult();
 
             _partitionKey = querySheet.PartitionKey;

--- a/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
+++ b/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
@@ -15,6 +15,7 @@ using CosmosDBStudio.ViewModel.Services;
 using CosmosDBStudio.ViewModel.TreeNodes;
 using EssentialMVVM;
 using Hamlet;
+using Linq.Extras;
 using Newtonsoft.Json.Linq;
 
 namespace CosmosDBStudio.ViewModel.EditorTabs
@@ -22,7 +23,6 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
     public class QuerySheetViewModel : TabViewModelBase, ISaveable
     {
         public static int UntitledCounter { get; set; }
-        private const string DefaultQuery = "select * from c";
         private readonly IViewModelFactory _viewModelFactory;
         private readonly IDialogService _dialogService;
         private readonly IMessenger _messenger;
@@ -48,7 +48,7 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
             _title = string.IsNullOrEmpty(path)
                 ? "Untitled " + (++UntitledCounter)
                 : Path.GetFileNameWithoutExtension(path);
-            _text = querySheet.Text == string.Empty ? DefaultQuery : querySheet.Text;
+            _text = querySheet.Text;
             _result = _viewModelFactory.CreateNotRunQueryResult();
 
             _partitionKey = querySheet.PartitionKey;

--- a/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
+++ b/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
@@ -22,6 +22,7 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
     public class QuerySheetViewModel : TabViewModelBase, ISaveable
     {
         public static int UntitledCounter { get; set; }
+
         private readonly IViewModelFactory _viewModelFactory;
         private readonly IDialogService _dialogService;
         private readonly IMessenger _messenger;

--- a/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
+++ b/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
@@ -15,7 +15,6 @@ using CosmosDBStudio.ViewModel.Services;
 using CosmosDBStudio.ViewModel.TreeNodes;
 using EssentialMVVM;
 using Hamlet;
-using Linq.Extras;
 using Newtonsoft.Json.Linq;
 
 namespace CosmosDBStudio.ViewModel.EditorTabs

--- a/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
+++ b/src/CosmosDBStudio.ViewModel/EditorTabs/QuerySheetViewModel.cs
@@ -21,8 +21,6 @@ namespace CosmosDBStudio.ViewModel.EditorTabs
 {
     public class QuerySheetViewModel : TabViewModelBase, ISaveable
     {
-        private const string DefaultQuery = "select * from c";
-
         public static int UntitledCounter { get; set; }
         private readonly IViewModelFactory _viewModelFactory;
         private readonly IDialogService _dialogService;


### PR DESCRIPTION
This adds a default query when opening the query sheet. I've found myself writing this query time and time again just to see some data on a collection. Saving a few keystrokes today saves fingers for the keystrokes of tomorrow...🖐🙂🖐