### PR TITLE
Make the database deletion more resilient to transient error

### DIFF
--- a/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
+++ b/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
@@ -76,6 +76,24 @@ namespace CosmosDBStudio.Model.Services.Implementation
             {
                 return OperationResult.NotFound;
             }
+            catch (CosmosException ex) when (IsTransient(ex.StatusCode))
+            {
+                try 
+                {
+                    await db.DeleteAsync(new RequestOptions { IfMatchEtag = database.ETag }, cancellationToken);
+                    return OperationResult.Success;
+                }
+                catch (CosmosException excp) when (excp.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return OperationResult.Success;
+                }
+            }
         }
+
+        static bool IsTransient(HttpStatusCode statusCode)
+            => statusCode == HttpStatusCode.ServiceUnavailable
+                || statusCode == HttpStatusCode.TooManyRequests
+                || statusCode == HttpStatusCode.RequestTimeout
+                || statusCode == HttpStatusCode.Gone;
     }
 }

--- a/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
+++ b/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
@@ -95,6 +95,7 @@ namespace CosmosDBStudio.Model.Services.Implementation
             => statusCode == HttpStatusCode.ServiceUnavailable
                 || statusCode == HttpStatusCode.TooManyRequests
                 || statusCode == HttpStatusCode.RequestTimeout
-                || statusCode == HttpStatusCode.Gone;
+                || statusCode == HttpStatusCode.Gone
+                || statusCode == (HttpStatusCode) 449;
     }
 }

--- a/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
+++ b/src/CosmosDBStudio.Model/Services/Implementation/DatabaseService.cs
@@ -83,7 +83,8 @@ namespace CosmosDBStudio.Model.Services.Implementation
                     await db.DeleteAsync(new RequestOptions { IfMatchEtag = database.ETag }, cancellationToken);
                     return OperationResult.Success;
                 }
-                catch (CosmosException excp) when (excp.StatusCode == HttpStatusCode.NotFound)
+                catch (CosmosException excp) when (excp.StatusCode == HttpStatusCode.NotFound
+                    || excp.StatusCode == HttpStatusCode.Gone)
                 {
                     return OperationResult.Success;
                 }


### PR DESCRIPTION
Fix https://github.com/thomaslevesque/CosmosDBStudio/issues/58

When transient error happens for database deletion, we will handle it by checking whether the database exist or not.
If it still exists, then we should delete it again; otherwise, we will ignore the new 404 NotFound because the 404 means the previous operation succeeded deleting the database.